### PR TITLE
Fix level not found message

### DIFF
--- a/Assets/GameAssets/Scripts/Systems/LevelManager.cs
+++ b/Assets/GameAssets/Scripts/Systems/LevelManager.cs
@@ -50,7 +50,7 @@ public class LevelManager : ILevelManager, IDisposable
                 }
             }
 
-            Debug.LogError($"Level Can Not Found: {levelName}");
+            Debug.LogError($"Level Not Found: {levelName}");
         };
     }
 


### PR DESCRIPTION
## Summary
- fix typo in level error message

## Testing
- `csc -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687baa758be48322be7f1626fd0aed54