### PR TITLE
Add chapter-based sound config loading

### DIFF
--- a/Assets/GameAssets/Scripts/Runtime/Bootstrapper.cs
+++ b/Assets/GameAssets/Scripts/Runtime/Bootstrapper.cs
@@ -5,14 +5,19 @@ using Zenject;
 public class Bootstrapper : MonoBehaviour
 {
     [SerializeField] private ChapterPoolSO[] allChapters;
+    [SerializeField] private ChapterSoundConfig[] allSoundConfigs;
+
     [Inject] private IPoolManager poolManager;
+    [Inject] private ISoundManager soundManager;
 
     private async void Start()
     {
         int chapterIdx = GetSelectedChapterIndex();
-        var selectedSO = allChapters[chapterIdx];
+        var selectedPoolSO = allChapters[chapterIdx];
+        var selectedSoundSO = allSoundConfigs[chapterIdx];
 
-        await poolManager.InitializeFromChapterSO(selectedSO);
+        soundManager.LoadChapterSounds(selectedSoundSO);
+        await poolManager.InitializeFromChapterSO(selectedPoolSO);
 
         SceneManager.LoadScene("Game");
     }


### PR DESCRIPTION
## Summary
- extend `Bootstrapper` to load chapter-specific sound configs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687babb6d3b88322a2fc0553b4ed323e