### PR TITLE
Add IDamageable interface and docs

### DIFF
--- a/Assets/GameAssets/Scripts/Core/IDamageable.cs
+++ b/Assets/GameAssets/Scripts/Core/IDamageable.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+/// <summary>
+/// Defines an object that can receive damage.
+/// </summary>
+public interface IDamageable
+{
+    /// <summary>
+    /// Apply damage to the object.
+    /// </summary>
+    /// <param name="amount">Amount of damage.</param>
+    void TakeDamage(float amount);
+}

--- a/Assets/GameAssets/Scripts/Runtime/Damageables/BreakableObject.cs
+++ b/Assets/GameAssets/Scripts/Runtime/Damageables/BreakableObject.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+public class BreakableObject : MonoBehaviour, IDamageable
+{
+    public float health = 50f;
+
+    public void TakeDamage(float amount)
+    {
+        health -= amount;
+        if (health <= 0f)
+        {
+            BreakObject();
+        }
+    }
+
+    private void BreakObject()
+    {
+        Debug.Log("Object has broken.");
+        Destroy(gameObject);
+    }
+}

--- a/Assets/GameAssets/Scripts/Runtime/Damageables/Door.cs
+++ b/Assets/GameAssets/Scripts/Runtime/Damageables/Door.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+public class Door : MonoBehaviour, IDamageable
+{
+    public float health = 100f;
+
+    public void TakeDamage(float amount)
+    {
+        health -= amount;
+        if (health <= 0f)
+        {
+            DestroyDoor();
+        }
+    }
+
+    private void DestroyDoor()
+    {
+        Debug.Log("Door has been destroyed.");
+        Destroy(gameObject);
+    }
+}

--- a/Assets/GameAssets/Scripts/Runtime/Damageables/FillableObject.cs
+++ b/Assets/GameAssets/Scripts/Runtime/Damageables/FillableObject.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+public class FillableObject : MonoBehaviour, IDamageable
+{
+    public float fillAmount = 100f;
+
+    public void TakeDamage(float amount)
+    {
+        fillAmount -= amount;
+        if (fillAmount <= 0f)
+        {
+            Debug.Log("Fillable object is depleted.");
+            Destroy(gameObject);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -29,5 +29,6 @@ UnityFramework is a small sample project illustrating how to combine reactive pr
 - **Dependency Injection** - Zenject installers define how systems are wired together.
 - **Addressables** - Levels and audio are loaded asynchronously to keep memory usage low.
 - **Service Interfaces** - Managers expose small interfaces so components remain decoupled.
+- **Damage System** - Objects implement `IDamageable` to react to damage. See `docs/IDamageable.md`.
 
 This repo is intended as a minimal showcase of these techniques rather than a complete game.

--- a/docs/IDamageable.md
+++ b/docs/IDamageable.md
@@ -1,0 +1,99 @@
+# IDamageable Interface
+
+`IDamageable` standardizes how game objects take damage. Any object
+implementing this interface can define its own behavior for receiving
+and reacting to damage. Doors, breakable props and even refillable
+objects can share the same contract, making gameplay systems easier to
+extend and maintain.
+
+## Interface Definition
+```csharp
+public interface IDamageable
+{
+    void TakeDamage(float amount);
+}
+```
+The interface exposes a single method `TakeDamage` which is called with
+the amount of damage dealt.
+
+## Usage Scenarios
+- **Doors** – can be damaged and destroyed once their health reaches
+  zero.
+- **Breakable Objects** – boxes or walls that shatter when damaged.
+- **Fillable Objects** – health stations or energy tanks that deplete
+  when hit.
+
+## Example Implementations
+
+### Door
+```csharp
+public class Door : MonoBehaviour, IDamageable
+{
+    public float health = 100f;
+
+    public void TakeDamage(float amount)
+    {
+        health -= amount;
+        if (health <= 0f)
+        {
+            DestroyDoor();
+        }
+    }
+
+    private void DestroyDoor()
+    {
+        Debug.Log("Door has been destroyed.");
+        Destroy(gameObject);
+    }
+}
+```
+
+### BreakableObject
+```csharp
+public class BreakableObject : MonoBehaviour, IDamageable
+{
+    public float health = 50f;
+
+    public void TakeDamage(float amount)
+    {
+        health -= amount;
+        if (health <= 0f)
+        {
+            BreakObject();
+        }
+    }
+
+    private void BreakObject()
+    {
+        Debug.Log("Object has broken.");
+        Destroy(gameObject);
+    }
+}
+```
+
+### FillableObject
+```csharp
+public class FillableObject : MonoBehaviour, IDamageable
+{
+    public float fillAmount = 100f;
+
+    public void TakeDamage(float amount)
+    {
+        fillAmount -= amount;
+        if (fillAmount <= 0f)
+        {
+            Debug.Log("Fillable object is depleted.");
+            Destroy(gameObject);
+        }
+    }
+}
+```
+
+## Benefits
+- **Modularity & Extensibility** – new damageable objects can be added
+  simply by implementing the interface.
+- **Reusability** – the same damage handling code can be shared across
+  different object types.
+- **Clean Code** – keeps damage logic localized to each object.
+- **SOLID Principles** – aligns with ISP and SRP by giving each object
+  a single responsibility for handling its own damage logic.


### PR DESCRIPTION
## Summary
- add `IDamageable` interface under Core scripts
- implement `Door`, `BreakableObject` and `FillableObject` examples
- document the interface in `docs/IDamageable.md`
- mention damage system in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687bd79257948322900a23f67f43869b