### PR TITLE
Add Slot Match Puzzle core scripts

### DIFF
--- a/Assets/GameAssets/Scripts/SlotMatchPuzzle/PieceType.cs
+++ b/Assets/GameAssets/Scripts/SlotMatchPuzzle/PieceType.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+public enum PieceType
+{
+    Heart,
+    Square,
+    Star,
+    Circle,
+    Triangle
+}

--- a/Assets/GameAssets/Scripts/SlotMatchPuzzle/PieceType.cs.meta
+++ b/Assets/GameAssets/Scripts/SlotMatchPuzzle/PieceType.cs.meta
@@ -1,0 +1,1 @@
+fileFormatVersion: 2

--- a/Assets/GameAssets/Scripts/SlotMatchPuzzle/PuzzleBoard.cs
+++ b/Assets/GameAssets/Scripts/SlotMatchPuzzle/PuzzleBoard.cs
@@ -1,0 +1,62 @@
+using UnityEngine;
+
+public class PuzzleBoard : MonoBehaviour
+{
+    public int rows = 6;
+    public int columns = 6;
+    public PuzzlePiece[,] grid;
+
+    private void Awake()
+    {
+        grid = new PuzzlePiece[rows, columns];
+        FillGrid();
+    }
+
+    public void FillGrid()
+    {
+        for (int r = 0; r < rows; r++)
+        {
+            for (int c = 0; c < columns; c++)
+            {
+                grid[r, c] = CreateRandomPiece(r, c);
+            }
+        }
+    }
+
+    private PuzzlePiece CreateRandomPiece(int r, int c)
+    {
+        PuzzlePiece piece = new PuzzlePiece();
+        piece.Type = (PieceType)Random.Range(0, System.Enum.GetValues(typeof(PieceType)).Length);
+        piece.GridPosition = new Vector2Int(r, c);
+        return piece;
+    }
+
+    public PuzzlePiece PickPiece(Vector2Int pos)
+    {
+        if (pos.x < 0 || pos.x >= rows || pos.y < 0 || pos.y >= columns)
+            return null;
+        var piece = grid[pos.x, pos.y];
+        grid[pos.x, pos.y] = null;
+        return piece;
+    }
+
+    public void ShiftRowsDown()
+    {
+        for (int r = rows - 1; r > 0; r--)
+        {
+            for (int c = 0; c < columns; c++)
+            {
+                grid[r, c] = grid[r - 1, c];
+                if (grid[r, c] != null)
+                {
+                    grid[r, c].GridPosition = new Vector2Int(r, c);
+                }
+            }
+        }
+
+        for (int c = 0; c < columns; c++)
+        {
+            grid[0, c] = CreateRandomPiece(0, c);
+        }
+    }
+}

--- a/Assets/GameAssets/Scripts/SlotMatchPuzzle/PuzzleBoard.cs.meta
+++ b/Assets/GameAssets/Scripts/SlotMatchPuzzle/PuzzleBoard.cs.meta
@@ -1,0 +1,1 @@
+fileFormatVersion: 2

--- a/Assets/GameAssets/Scripts/SlotMatchPuzzle/PuzzleController.cs
+++ b/Assets/GameAssets/Scripts/SlotMatchPuzzle/PuzzleController.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+public class PuzzleController : MonoBehaviour
+{
+    public PuzzleBoard board;
+    public SlotBar slotBar;
+
+    private int moveCount = 30;
+
+    private void OnEnable()
+    {
+        slotBar.OnMatch += HandleMatch;
+    }
+
+    private void OnDisable()
+    {
+        slotBar.OnMatch -= HandleMatch;
+    }
+
+    public void SelectPiece(Vector2Int gridPos)
+    {
+        if (moveCount <= 0) return;
+        var piece = board.PickPiece(gridPos);
+        if (piece != null && slotBar.AddPiece(piece))
+        {
+            moveCount--;
+        }
+    }
+
+    public void Swap(int indexA, int indexB)
+    {
+        if (moveCount <= 0) return;
+        slotBar.Swap(indexA, indexB);
+        moveCount--;
+    }
+
+    private void HandleMatch(System.Collections.Generic.List<PuzzlePiece> matched)
+    {
+        board.ShiftRowsDown();
+    }
+}

--- a/Assets/GameAssets/Scripts/SlotMatchPuzzle/PuzzleController.cs.meta
+++ b/Assets/GameAssets/Scripts/SlotMatchPuzzle/PuzzleController.cs.meta
@@ -1,0 +1,1 @@
+fileFormatVersion: 2

--- a/Assets/GameAssets/Scripts/SlotMatchPuzzle/PuzzlePiece.cs
+++ b/Assets/GameAssets/Scripts/SlotMatchPuzzle/PuzzlePiece.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+[System.Serializable]
+public class PuzzlePiece
+{
+    public PieceType Type;
+    public Vector2Int GridPosition;
+}

--- a/Assets/GameAssets/Scripts/SlotMatchPuzzle/PuzzlePiece.cs.meta
+++ b/Assets/GameAssets/Scripts/SlotMatchPuzzle/PuzzlePiece.cs.meta
@@ -1,0 +1,1 @@
+fileFormatVersion: 2

--- a/Assets/GameAssets/Scripts/SlotMatchPuzzle/SlotBar.cs
+++ b/Assets/GameAssets/Scripts/SlotMatchPuzzle/SlotBar.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SlotBar : MonoBehaviour
+{
+    public int slotCount = 7;
+    public List<PuzzlePiece> slots = new List<PuzzlePiece>();
+
+    public delegate void MatchHandler(List<PuzzlePiece> matched);
+    public event MatchHandler OnMatch;
+
+    private void Awake()
+    {
+        for (int i = 0; i < slotCount; i++)
+        {
+            slots.Add(null);
+        }
+    }
+
+    public bool AddPiece(PuzzlePiece piece)
+    {
+        for (int i = 0; i < slots.Count; i++)
+        {
+            if (slots[i] == null)
+            {
+                slots[i] = piece;
+                CheckForMatch(i);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void Swap(int indexA, int indexB)
+    {
+        if (indexA < 0 || indexA >= slotCount || indexB < 0 || indexB >= slotCount)
+            return;
+        var temp = slots[indexA];
+        slots[indexA] = slots[indexB];
+        slots[indexB] = temp;
+        CheckForMatch(indexA);
+        CheckForMatch(indexB);
+    }
+
+    private void CheckForMatch(int index)
+    {
+        var piece = slots[index];
+        if (piece == null) return;
+
+        int left = index;
+        while (left > 0 && slots[left - 1] != null && slots[left - 1].Type == piece.Type)
+            left--;
+
+        int right = index;
+        while (right < slotCount - 1 && slots[right + 1] != null && slots[right + 1].Type == piece.Type)
+            right++;
+
+        if (right - left + 1 >= 3)
+        {
+            List<PuzzlePiece> matched = new List<PuzzlePiece>();
+            for (int i = left; i <= right; i++)
+            {
+                matched.Add(slots[i]);
+                slots[i] = null;
+            }
+            OnMatch?.Invoke(matched);
+        }
+    }
+}

--- a/Assets/GameAssets/Scripts/SlotMatchPuzzle/SlotBar.cs.meta
+++ b/Assets/GameAssets/Scripts/SlotMatchPuzzle/SlotBar.cs.meta
@@ -1,0 +1,1 @@
+fileFormatVersion: 2

--- a/docs/SlotMatchPuzzle.md
+++ b/docs/SlotMatchPuzzle.md
@@ -1,0 +1,51 @@
+# Slot Match Puzzle
+
+Bu doküman, seviyelere dayalı bir match3 türevi olarak tasarlanan **Slot Match Puzzle** oyun fikrinin özetini sunar. Klasik eşleştirme formülüne slot bar ve serbest sürükleme mekanikleri eklenmiştir. Amaç, sınırlı hamle sayısı içinde hedefleri tamamlamak ve yüksek puana ulaşmaktır.
+
+## Oyun Mekanikleri
+
+### Grid & Objeler
+- Oyun alanında rastgele yerleştirilmiş farklı şekiller bulunur (kalp, kare, yıldız, daire, üçgen vb.).
+- Grid boyutu seviye ilerledikçe değişebilir (6x6, 7x7, 8x8...).
+
+### Slot Bar
+- Gridin altında belirli sayıda slot barı vardır (örn. 7 slot).
+- Griddeki herhangi bir objeye tıklandığında obje ilk boş slota gider.
+- Slotlardaki taşlar sağa/sola sürüklenerek yer değiştirebilir.
+- Bazı taşlar kilitli olabilir ve yerlerinden oynatılamaz.
+- Slottaki taşlar istenirse orijinal konumlarına geri çağrılabilir.
+
+### Eşleştirme ve Puanlama
+- Yan yana 3 veya daha fazla aynı obje geldiğinde otomatik olarak eşleşir ve silinir.
+- Tek hamlede birden çok eşleşme yapılırsa **combo** puanı alınır.
+- 5'li veya daha büyük eşleşmeler ekstra skor ve özel animasyon kazandırır.
+
+### Hamle Sistemi
+- Her seviye belirli sayıda hamleyle başlar.
+- Gridden obje seçmek ya da slotta sürükleme yapmak hamle harcar.
+- Hamleler bitmeden hedefler tamamlanmazsa seviye kaybedilir.
+
+### Görevler & Seviye Tasarımı
+- "15 kırmızı topla", "3 defa 5'li eşleşme yap" gibi hedefler bulunur.
+- Görevler bitince bir sonraki seviye açılır.
+- Seviye ilerledikçe grid büyür ve kilitli taşlar gibi yeni engeller eklenir.
+
+### Kaybetme / Kazanma
+- Tüm görevler tamamlanırsa seviye geçilir.
+- Hamleler biter ve görevler tamamlanmazsa seviye başarısız olur.
+
+### Row Shift Mekaniği
+- Eşleşme yapıldığında griddeki tüm satırlar bir aşağı kayar.
+- En alttaki satırdan taşlar silinir, en üst satır yeni objelerle dolar.
+- Böylece her hamlede grid tazelenir ve slot makinesi hissi oluşur.
+
+## Oyun Akışı Kısa Özet
+1. Seviye yüklenir ve grid oluşur.
+2. Oyuncu gridden taş seçip slot bara gönderir, burada dizilişi değiştirir.
+3. Eşleşmeler gerçekleştikçe puan toplanır ve satırlar kayar.
+4. Hamle sayısı sıfırlanmadan hedefler tamamlanırsa seviye geçilir.
+
+## Geliştirme Notları
+- **Animasyon odaklı hareketler:** Taşların hareketleri ve slot bar kaymaları için animasyon kullanın. Animasyon bitişlerinde event tetikleyip oyun akışını kontrol edin.
+- Sistemin animatif olması, özellikle "row shift" sırasında görsel geri bildirim sağlar.
+


### PR DESCRIPTION
## Summary
- implement core components for Slot Match Puzzle
- PuzzleBoard creates the grid and handles row shifts
- SlotBar stores pieces and checks for matches
- PuzzleController coordinates moves between grid and slot bar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e5dd067488322a3178cd68c254c5e